### PR TITLE
Fix incorrect transposition in get_cylindrical_velocity_interpolators() and vector_interpolator() docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Release 0.1.1 (TBD)
 
 Bug fixes:
 * Fix numpy array setflags() bug in UnstructGrid2D pickling. (#4)
+* Fix incorrect transposition in get_cylindrical_velocity_interpolators(). (#5)
 
 
 Release 0.1.0 (22 Sep 2023)

--- a/cherab/imas/ggd/base_mesh.py
+++ b/cherab/imas/ggd/base_mesh.py
@@ -131,7 +131,7 @@ class GGDGrid:
         On the second and subsequent calls, the interpolator is created as an instance
         of the previously created interpolator.
 
-        :param grid_vectors: A (num_cell, 3) array containing 3D vectors in the grid cells.
+        :param grid_vectors: A (3, num_cell) array containing 3D vectors in the grid cells.
         :param fill_vector: A 3D vector returned outside the gird. Default is (0, 0, 0).
 
         :returns: VectorFunctionND interpolator

--- a/cherab/imas/ggd/unstruct_2d_mesh.py
+++ b/cherab/imas/ggd/unstruct_2d_mesh.py
@@ -265,7 +265,7 @@ class UnstructGrid2D(GGDGrid):
         On the second and subsequent calls, the interpolator is created as an instance
         of the previously created interpolator sharing the same KDtree structure.
 
-        :param grid_vectors: A (K,3) array containing 3D vectors in the grid cells.
+        :param grid_vectors: A (3,K) array containing 3D vectors in the grid cells.
         :param fill_vector: A 3D vector returned outside the gird. Default is (0, 0, 0).
 
         :returns: UnstructGridVectorFunction2D interpolator

--- a/cherab/imas/plasma/edge.py
+++ b/cherab/imas/plasma/edge.py
@@ -219,7 +219,7 @@ def get_cylindrical_velocity_interpolators(grid, vr, vz, vtor):
     if vtor is None:
         vtor = np.zeros(grid.num_cell, dtype=np.float64)
 
-    return grid.vector_interpolator(np.array([vr, vtor, vz]).T)
+    return grid.vector_interpolator(np.array([vr, vtor, vz]))
 
 
 def get_parallel_velocity_interpolators(grid, vpar, vrad, b_field):


### PR DESCRIPTION
This fixes #5 by removing incorrect transposition in `imas.plasma.edge.get_cylindrical_velocity_interpolators()` and correcting docstrings for `GGDGrid.vector_interpolator()` and `UnstructGrid2D.vector_interpolator()`.