### PR TITLE
Add support for Cherab 1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Release 0.1.1 (TBD)
 -------------------
 
+New:
+* Support Cython 3 stable release
+* Support Cherab 1.5
+
 Bug fixes:
 * Fix numpy array setflags() bug in UnstructGrid2D pickling. (#4)
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-include README.md CHANGELOG.md MANIFEST.in setup.py
-recursive-include cherab *.py
-prune demos*

--- a/README.md
+++ b/README.md
@@ -8,16 +8,20 @@ This module enables the creation of Cherab plasma objects and Raysect meshes fro
 
 This add-on module requires IMAS to be installed with Python interface. 
 
-On ITER SDCC load the respective modules:
+On ITER SDCC load the IMAS module:
 
 ```bash
 module load IMAS
-module load Raysect/0.7.1-intel-2020b
 ```
 and then install with:
 
 ```bash
-pip install cherab==1.4.0 --user
-pip install -U cython==3.0a5 --user
-pip install <path-to-cherab-imas> --user
+pip install git@https://github.com/cherab/imas --user
+```
+Alternatively, install to a virtual environment:
+
+```bash
+python -m venv /path/to/cherab_virtual_environment
+source /path/to/cherab_virtual_environment/bin/activate
+pip install git@https://github.com/cherab/imas
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython==3.0a5", "raysect==0.8.1", "cherab==1.5.0.dev1"]
+requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython~=3.0", "raysect==0.8.1.*", "cherab==1.5"]
 build-backend="setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "oldest-supported-numpy", "cython~=3.0", "raysect==0.8.1.*", "cherab==1.5"]
+requires = ["setuptools", "oldest-supported-numpy", "cython~=3.0", "raysect==0.8.1.*", "cherab==1.5.*"]
 build-backend="setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -71,8 +71,11 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=find_packages(),
-    include_package_data=True,
+    package_data={"": [
+        "**/*.pyx", "**/*.pxd",  # Needed to build Cython extensions.
+        ],
+    },
+    data_files=data_files,
     install_requires=["raysect==0.8.1.*", "cherab==1.5.*"],
     ext_modules=cythonize(extensions, force=force, compiler_directives=cython_directives),
-    data_files=data_files,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
+from collections import defaultdict
 from setuptools import setup, find_packages, Extension
 from Cython.Build import cythonize
 import sys
 import numpy
 import os
 import os.path as path
+from pathlib import Path
 
 force = False
 profile = False
@@ -33,12 +35,22 @@ cython_directives = {"language_level": 3}
 if profile:
     cython_directives["profile"] = True
 
+# Include demos in a separate directory in the distribution as data_files.
+demo_parent_path = Path("share/cherab/demos/imas")
+data_files = defaultdict(list)
+demos_source = Path("demos")
+for item in demos_source.rglob("*"):
+    if item.is_file():
+        install_dir = demo_parent_path / item.parent.relative_to(demos_source)
+        data_files[str(install_dir)].append(str(item))
+data_files = list(data_files.items())
+
 with open("README.md") as f:
     long_description = f.read()
 
 setup(
     name="cherab-imas",
-    version="0.1.0",
+    version="0.1.1",
     namespace_packages=['cherab'],
     description="Cherab spectroscopy framework: IMAS submodule",
     classifiers=[
@@ -60,6 +72,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["raysect==0.8.1", "cherab==1.5.0.dev1"],
+    install_requires=["cherab==1.5"],
     ext_modules=cythonize(extensions, force=force, compiler_directives=cython_directives),
+    data_files=data_files,
 )

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["cherab==1.5"],
+    install_requires=["raysect==0.8.1.*", "cherab==1.5.*"],
     ext_modules=cythonize(extensions, force=force, compiler_directives=cython_directives),
     data_files=data_files,
 )


### PR DESCRIPTION
This PR updates the setup files to support Cherab 1.5 and install demos in `share/cherab/demos/imas`.