### PR TITLE
✨ Add bolometer observers for IMAS IDS

### DIFF
--- a/cherab/imas/ids/bolometer/__init__.py
+++ b/cherab/imas/ids/bolometer/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2023 Euratom
+# Copyright 2023 United Kingdom Atomic Energy Authority
+# Copyright 2023 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+#
+# Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
+# European Commission - subsequent versions of the EUPL (the "Licence");
+# You may not use this work except in compliance with the Licence.
+# You may obtain a copy of the Licence at:
+#
+# https://joinup.ec.europa.eu/software/page/eupl5
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.
+#
+# See the Licence for the specific language governing permissions and limitations
+# under the Licence.
+
+from .load_channels import load_channels
+from .utility import GEOMETRY_TYPE

--- a/cherab/imas/ids/bolometer/load_channels.py
+++ b/cherab/imas/ids/bolometer/load_channels.py
@@ -1,0 +1,155 @@
+# Copyright 2023 Euratom
+# Copyright 2023 United Kingdom Atomic Energy Authority
+# Copyright 2023 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+#
+# Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
+# European Commission - subsequent versions of the EUPL (the "Licence");
+# You may not use this work except in compliance with the Licence.
+# You may obtain a copy of the Licence at:
+#
+# https://joinup.ec.europa.eu/software/page/eupl5
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.
+#
+# See the Licence for the specific language governing permissions and limitations
+# under the Licence.
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from imas import bolometer  # type: ignore
+from raysect.core.math import Point3D, Vector3D
+
+from .utility import GEOMETRY_TYPE
+
+
+def load_channels(bolometer_ids: bolometer) -> dict[str, dict[str, Any]]:
+    """Load bolometer channels from the bolometer IDS.
+
+    :param bolometer_ids: The bolometer IDS.
+
+    :returns: A dictionary with the following keys:
+        'channel_name': A dictionary with the following keys:
+            'foil': A dictionary with the following keys:
+                'centre': A Point3D with the coordinates of the foil centre,
+                'type': The geometry type of the foil,
+                'basis_x': A Vector3D with the x-basis vector of the foil,
+                'basis_y': A Vector3D with the y-basis vector of the foil,
+                'basis_z': A Vector3D with the z-basis vector of the foil,
+                'dx': The width of the foil in the x-direction [m],
+                'dy': The width of the foil in the y-direction [m],
+                'surface': The surface area of the foil [m^2],
+                'radius': The radius of the foil [m] if the geometry type is circular,
+                'coords': The outline coordinates for basis_x and basis_y if the geometry type is outline,
+            'slit': A dictionary with the following keys:
+                'centre': A Point3D with the coordinates of the slit centre,
+                'type': The geometry type of the slit,
+                'basis_x': A Vector3D with the x-basis vector of the slit,
+                'basis_y': A Vector3D with the y-basis vector of the slit,
+                'basis_z': A Vector3D with the z-basis vector of the slit,
+                'dx': The width of the slit in the x-direction [m],
+                'dy': The width of the slit in the y-direction [m],
+                'surface': The surface area of the slit [m^2],
+                'radius': The radius of the slit [m] if the geometry type is circular,
+                'coords': The outline coordinates for basis_x and basis_y if the geometry type is outline.
+    """
+    if not isinstance(bolometer_ids, bolometer):
+        raise ValueError("Invalid bolometer IDS")
+
+    channels = getattr(bolometer_ids, "channel", [])
+    if not len(channels):
+        raise RuntimeError("No channels found in bolometer")
+
+    bolo_data = {}
+
+    for channel in channels:
+        name = channel.name
+        bolo_data[name] = {
+            "foil": load_geometry(channel.detector),
+            "slit": load_geometry(channel.aperture[0]),
+        }
+
+    return bolo_data
+
+
+def load_geometry(sensor) -> dict[str, Any]:
+    """Load the geometry of a sensor.
+
+    :param sensor: detector or aperture structure object.
+
+    :returns: A dictionary with the following keys:
+        'centre': A Point3D with the coordinates of the sensor centre,
+        'type': The geometry type of the sensor,
+        'basis_x': A Vector3D with the x-basis vector of the sensor,
+        'basis_y': A Vector3D with the y-basis vector of the sensor,
+        'basis_z': A Vector3D with the z-basis vector of the sensor,
+        'dx': The width of the sensor in the x-direction [m],
+        'dy': The width of the sensor in the y-direction [m],
+        'surface': The surface area of the sensor [m^2],
+        'radius': The radius of the sensor [m] if the geometry type is circular,
+        'coords': The outline coordinates for basis_x and basis_y if the geometry type is outline.
+    """
+    geometry = {}
+
+    centre = sensor.centre
+    geometry["centre"] = Point3D(*_cylin_to_cart(centre.r, centre.phi, centre.z))
+
+    geometry_type = GEOMETRY_TYPE.from_value(sensor.geometry_type)
+
+    if geometry_type == GEOMETRY_TYPE.RECTANGLE:
+        # Geometry type: rectangle
+        geometry["type"] = GEOMETRY_TYPE.RECTANGLE
+
+        # Unit vectors
+        geometry["basis_x"] = Vector3D(
+            sensor.x2_unit_vector.x, sensor.x2_unit_vector.y, sensor.x2_unit_vector.z
+        )
+        geometry["basis_y"] = Vector3D(
+            sensor.x1_unit_vector.x, sensor.x1_unit_vector.y, sensor.x1_unit_vector.z
+        )
+        geometry["basis_z"] = Vector3D(
+            sensor.x3_unit_vector.x, sensor.x3_unit_vector.y, sensor.x3_unit_vector.z
+        )
+
+        # Dimensions
+        geometry["dx"] = sensor.x2_width
+        geometry["dy"] = sensor.x1_width
+
+        # Area
+        geometry["surface"] = getattr(sensor, "surface", None)
+
+    if geometry_type == GEOMETRY_TYPE.CIRCULAR:
+        # Geometry type: circular
+        geometry["type"] = GEOMETRY_TYPE.CIRCULAR
+
+        # Radius
+        radius = getattr(sensor, "radius", None)
+        if radius is None or radius <= 0:
+            raise ValueError("Invalid radius")
+
+    if geometry_type == GEOMETRY_TYPE.OUTLINE:
+        # Geometry type: outline
+        geometry["type"] = GEOMETRY_TYPE.OUTLINE
+
+        # Outline coordinates for basis_x and basis_y
+        geometry["coords"] = np.vstack((sensor.outline.x2, sensor.outline.x1))
+
+    return geometry
+
+
+def _cylin_to_cart(r, phi, z) -> tuple[float, float, float]:
+    """Convert cylindrical coordinates to cartesian coordinates.
+
+    :param r: radial coordinate
+    :param phi: azimuthal coordinate
+    :param z: vertical coordinate
+
+    :returns: A tuple with the x, y, and z coordinates.
+    """
+    x = r * np.cos(phi)
+    y = r * np.sin(phi)
+    return x, y, z

--- a/cherab/imas/ids/bolometer/load_channels.py
+++ b/cherab/imas/ids/bolometer/load_channels.py
@@ -115,6 +115,10 @@ def load_geometry(sensor) -> dict[str, Any]:
             sensor.x3_unit_vector.x, sensor.x3_unit_vector.y, sensor.x3_unit_vector.z
         )
 
+        # Check if bases are in RHS (assume that basis_z is a vector targetting the plasma)
+        if geometry["basis_z"].dot(geometry["basis_x"].cross(geometry["basis_y"])) < 0:
+            geometry["basis_y"] *= -1
+
         # Dimensions
         geometry["dx"] = sensor.x2_width
         geometry["dy"] = sensor.x1_width

--- a/cherab/imas/ids/bolometer/utility.py
+++ b/cherab/imas/ids/bolometer/utility.py
@@ -1,0 +1,43 @@
+# Copyright 2023 Euratom
+# Copyright 2023 United Kingdom Atomic Energy Authority
+# Copyright 2023 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+#
+# Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
+# European Commission - subsequent versions of the EUPL (the "Licence");
+# You may not use this work except in compliance with the Licence.
+# You may obtain a copy of the Licence at:
+#
+# https://joinup.ec.europa.eu/software/page/eupl5
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.
+#
+# See the Licence for the specific language governing permissions and limitations
+# under the Licence.
+
+from enum import Enum
+
+__all__ = ["GEOMETRY_TYPE"]
+
+
+class GEOMETRY_TYPE(Enum):
+    """Enum for geometry type.
+
+    The geometry type of the bolometer foil or slit.
+    """
+
+    OUTLINE = 1
+    CIRCULAR = 2
+    RECTANGLE = 3
+
+    @classmethod
+    def from_value(cls, value):
+        """Get the geometry type from a value.
+
+        :param value: The integer value to convert to a geometry type.
+            If the value is not a valid geometry type, the default is `RECTANGLE`.
+        """
+        if value in cls._value2member_map_:
+            return cls(value)
+        return cls.RECTANGLE

--- a/cherab/imas/observers/__init__.py
+++ b/cherab/imas/observers/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2023 Euratom
+# Copyright 2023 United Kingdom Atomic Energy Authority
+# Copyright 2023 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+#
+# Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
+# European Commission - subsequent versions of the EUPL (the "Licence");
+# You may not use this work except in compliance with the Licence.
+# You may obtain a copy of the Licence at:
+#
+# https://joinup.ec.europa.eu/software/page/eupl5
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.
+#
+# See the Licence for the specific language governing permissions and limitations
+# under the Licence.
+
+from .bolometer import load_bolometers

--- a/cherab/imas/observers/bolometer.py
+++ b/cherab/imas/observers/bolometer.py
@@ -1,0 +1,117 @@
+# Copyright 2023 Euratom
+# Copyright 2023 United Kingdom Atomic Energy Authority
+# Copyright 2023 Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas
+#
+# Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
+# European Commission - subsequent versions of the EUPL (the "Licence");
+# You may not use this work except in compliance with the Licence.
+# You may obtain a copy of the Licence at:
+#
+# https://joinup.ec.europa.eu/software/page/eupl5
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the Licence is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.
+#
+# See the Licence for the specific language governing permissions and limitations
+# under the Licence.
+
+from __future__ import annotations
+
+from typing import Literal
+
+from imas import DBEntry  # type: ignore
+from raysect.core import Node
+
+from cherab.tools.observers.bolometry import BolometerCamera, BolometerFoil, BolometerSlit
+
+from ..ids.bolometer import GEOMETRY_TYPE, load_channels
+from ..ids.common import get_ids_time_slice
+
+Backends = Literal["hdf5", "mdsplus", "uda", "memory"]
+
+
+def load_bolometers(
+    *args, backend: Backends = "hdf5", host: str | None = None, parent: Node | None = None
+) -> list[BolometerCamera]:
+    """Load bolometer cameras from IMAS bolometer IDS.
+
+    :param *args: variable length argument list.
+        If one argument is provided, it is assumed to be the path to the bolometer IDS.
+        If four arguments are provided, they are assumed to be the *shot*, *run*, *user*, and
+        *database* name. The version is assumed to be 3.
+        Otherwise, a ValueError is raised.
+    :param backend: IMAS database backend to use, by default "hdf5".
+    :param host: IMAS database host address, by default None.
+        When the database is located at another host, the host address must be provided.
+    :param parent: The parent node in the Raysect scene-graph.
+
+    :returns: A list of `BolometerCamera` objects.
+    """
+    if host is None:
+        uri = f"imas:{backend}?"
+    else:
+        uri = f"imas://{host}/{backend}?"
+
+    if len(args) == 1:
+        uri += f"path={args[0]}"
+
+    elif len(args) == 4:
+        uri += f"shot={args[0]};run={args[1]};user={args[2]};database={args[3]};version=3"
+
+    else:
+        raise ValueError(f"Invalid number of arguments {len(args)}")
+
+    entry = DBEntry(uri=uri, mode="r")  # type: ignore
+    bolometer_ids = get_ids_time_slice(entry, "bolometer")
+
+    bolo_data = load_channels(bolometer_ids)
+
+    bolo_cameras = []
+
+    for name, values in bolo_data.items():
+        slit_data = values["slit"]
+        foil_data = values["foil"]
+
+        # Create BolometerCamera object
+        camera = BolometerCamera(parent=parent, name=name)
+
+        # Create slit object
+        if slit_data["type"] != GEOMETRY_TYPE.OUTLINE:
+            slit = BolometerSlit(
+                f"slit-{name}",
+                slit_data["centre"],
+                slit_data["basis_x"],
+                slit_data["dx"],
+                slit_data["basis_y"],
+                slit_data["dy"],
+                curvature_radius=slit_data["radius"]
+                if slit_data["type"] == GEOMETRY_TYPE.CIRCULAR
+                else 0.0,
+                parent=camera,
+            )
+        else:
+            raise NotImplementedError("Outline geometry not supported yet.")
+
+        # Create foil object
+        if foil_data["type"] != GEOMETRY_TYPE.OUTLINE:
+            foil = BolometerFoil(
+                f"foil-{name}",
+                foil_data["centre"],
+                foil_data["basis_x"],
+                foil_data["dx"],
+                foil_data["basis_y"],
+                foil_data["dy"],
+                slit,
+                curvature_radius=foil_data["radius"]
+                if foil_data["type"] == GEOMETRY_TYPE.CIRCULAR
+                else 0.0,
+                parent=camera,
+            )
+        else:
+            raise NotImplementedError("Outline geometry not supported yet.")
+
+        camera.add_foil_detector(foil)
+        bolo_cameras.append(camera)
+
+    return bolo_cameras

--- a/demos/ITER/bolometer_lines_of_sight.py
+++ b/demos/ITER/bolometer_lines_of_sight.py
@@ -1,0 +1,67 @@
+"""This demo creates a BolometerCamera object and plots the lines of sight with machine wall outline.
+
+Tested on ITER IMAS database.
+"""
+
+from pathlib import Path
+
+import numpy as np
+from matplotlib import pyplot as plt
+from raysect.core import Ray
+from raysect.optical import World
+
+from cherab.imas.observers import load_bolometers
+from cherab.imas.wall import load_wall_outline
+
+# Default ITER IMAS quaries
+DATABASE = "ITER_MD"
+USER = "public"
+SHOT_BOLO = 150401
+SHOT_WALL = 116000
+RUN_BOLO = 3
+RUN_WALL = 4
+
+# Raysect root scene-graph
+world = World()
+
+# Load bolometer camera
+bolos = load_bolometers(SHOT_BOLO, RUN_BOLO, USER, DATABASE)
+
+# Load machine wall outline
+wall = load_wall_outline(SHOT_WALL, RUN_WALL, USER, DATABASE)
+first_wall = wall["First Wall"]
+divertor = wall["Divertor"]
+
+# %%
+# Plot the bolometer lines of sight
+# ---------------------------------
+fig, ax = plt.subplots(layout="constrained")
+
+# Plot the machine wall outline
+ax.plot(first_wall[:, 0], first_wall[:, 1], color="black", zorder=-1)
+ax.plot(divertor[:, 0], divertor[:, 1], color="black", zorder=-1)
+
+# Plot the bolometer lines of sight
+for bolo in bolos:
+    origin = bolo.foil_detectors[0].centre_point
+    los_vector = bolo.foil_detectors[0].sightline_vector
+    los_ray = Ray(origin, los_vector)
+
+    los_line = np.array([[*los_ray.point_on(i)] for i in range(0, 20)])
+
+    # Project the line of sight onto the R-Z plane
+    r, z = np.hypot(los_line[:, 0], los_line[:, 1]), los_line[:, 2]
+    ax.plot(r, z, color="red", lw=0.25)
+
+ax.set_xlabel("$R$ [m]")
+ax.set_ylabel("$Z$ [m]")
+ax.set_aspect("equal")
+
+# Save the plot
+plots_path = Path(__file__).parent / "plots"
+plots_path.mkdir(exist_ok=True)
+fig.savefig(
+    plots_path / f"bolometer_lines_of_sight_{SHOT_BOLO}_{RUN_BOLO}.png",
+    bbox_inches="tight",
+    dpi=200,
+)


### PR DESCRIPTION
Hi!

This PR adds new files to the `cherab/imas/observers` directory to implement bolometer observers for the IMAS IDS. The `bolometer.py` file contains the implementation of the `load_bolometers` function, which loads bolometer cameras from the IMAS bolometer IDS. The function takes various arguments to specify the database and backend, and returns a list of `BolometerCamera` objects.

The commit also adds new files to the `cherab/imas/ids/bolometer` directory, including `utility.py` and `load_channels.py`. The `utility.py` file contains the implementation of the `GEOMETRY_TYPE` enum, which represents the geometry type of the bolometer foil or slit.
The `load_channels.py` file contains the implementation of the `load_channels` function which loads bolometer-related data from IMAS bolometer IDS.

Moreover, I added the demo script, which plots the bolometer lines of sight and machine wall outlines in the ITER database.
I put this result here.
![bolometer_lines_of_sight_150401_3](https://github.com/user-attachments/assets/809fd27b-6130-498a-b7dc-a62f7fd8a819)

Lastly, I implemented these codes for general machines. Actually, I designed one `BolometerCamera` with only one pair of `BolometerFoil` and `BolometerSlit` instances. This comes from the specification of the IMAS Data Dictionary structure.

So, as a next step, I will try to create a bolometer camera containing several foils and slits which have a save camera housing and implement them into a specific machine package like `cherab.iter.observers.bolometry`.

I would appreciate your review of my changes and comment on them. 😊