### PR TITLE
Update deployment trigger for GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: 🚀 Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
Change the deployment condition to trigger on pushes to the master branch instead of on release events. This adjustment streamlines the deployment process for updates.