### PR TITLE
📝 Update documentation and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@
 [pypi]: https://pypi.org/project/cherab-imas/
 [pypi-badge]: https://img.shields.io/pypi/v/cherab-imas?label=PyPI&logo=pypi&logoColor=gold&style=flat-square
 [pypi-publish]: https://github.com/cherab/imas/actions/workflows/deploy-pypi.yml
-[pypi-publish-badge]: https://img.shields.io/github/actions/workflow/status/cherab/imas/deploy-pypi.yml?style=flat-square&label=PyPI%20Publish&logo=github
+[pypi-publish-badge]: https://img.shields.io/github/actions/workflow/status/cherab/imas/deploy-pypi.yml?event=release&style=flat-square&logo=github&label=PyPI%20Publish
 [python-badge]: https://img.shields.io/pypi/pyversions/cherab-imas?logo=Python&logoColor=gold&style=flat-square
 
 ---
 
-`cherab` add-on module for IMAS (Integrated Modelling & Analysis Suite).
+[`cherab`](https://github.com/cherab/core) add-on module for **IMAS** (Integrated Modelling & Analysis Suite).
 
-This module enables the creation of `cherab`'s functional objects (e.g. plasma, observers, meshes, etc.) from IMAS IDS (Interface Data Structures).
+This module enables the creation of `cherab`'s functional objects (e.g. plasma, observers, meshes, etc.) from IMAS IDSs (Interface Data Structures).
 
 <!-- END-HEADER -->
 

--- a/docs/source/intro.md
+++ b/docs/source/intro.md
@@ -2,7 +2,7 @@
 
 # 🚀 Get Started
 
-This page gives a quick overview of how to get started with `cherab-imas`, and how to use it within Docutils and Sphinx.
+This page gives a quick overview of how to get started with `cherab-imas`, including installation instructions and a simple example script.
 
 ## Installation
 


### PR DESCRIPTION
Fix the description on the Get Started page for clarity and update the PyPI publish badge URL. Key changes include improved module description and enhanced clarity in installation instructions.