### PR TITLE
📝 Fix plotly renderer selection in notebook

### DIFF
--- a/docs/notebooks/radiation/grid_3d.ipynb
+++ b/docs/notebooks/radiation/grid_3d.ipynb
@@ -236,10 +236,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import plotly.graph_objects as go\n",
-    "from plotly import io\n",
-    "\n",
-    "io.renderers.default = \"png\""
+    "import plotly.graph_objects as go"
    ]
   },
   {
@@ -335,6 +332,9 @@
     "        eye=dict(x=0.0, y=-2.0, z=0.25),\n",
     "    ),\n",
     "    template=\"plotly_dark\",\n",
+    ")\n",
+    "fig.show(\n",
+    "    renderer=\"png\",\n",
     ")"
    ]
   }


### PR DESCRIPTION
Key changes:

- Updated the notebook to select the plotly renderer at `fig.show()`.

- Removed unnecessary import and default renderer setting.